### PR TITLE
Fix sequence deletion after nextval call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Incorrect, off-spec MP Ext type: caused runtime errors on some platforms.
 - Panic in coio test starting from 1.80 Rust.
 - Impossible to use procedural macros(like `tarantool::proc`, `tarantool::test`) through reexporting tarantool.
+- Error deleting sequence after calling next().
 
 ### Deprecated
 - tlua::LuaTable::get_or_create_metatable is deprecated now in favor of tlua::LuaTable::metatable.

--- a/tarantool/src/schema/sequence.rs
+++ b/tarantool/src/schema/sequence.rs
@@ -8,11 +8,11 @@ use crate::space::{Space, SystemSpace};
 pub fn drop_sequence(seq_id: u32) -> Result<(), Error> {
     schema::revoke_object_privileges("sequence", seq_id)?;
 
-    let sys_sequence: Space = SystemSpace::Sequence.into();
-    sys_sequence.delete(&(seq_id,))?;
-
     let sys_sequence_data: Space = SystemSpace::SequenceData.into();
     sys_sequence_data.delete(&(seq_id,))?;
+
+    let sys_sequence: Space = SystemSpace::Sequence.into();
+    sys_sequence.delete(&(seq_id,))?;
 
     Ok(())
 }

--- a/tarantool/src/sequence.rs
+++ b/tarantool/src/sequence.rs
@@ -22,6 +22,11 @@ impl Sequence {
         })
     }
 
+    /// Get sequence id.
+    pub fn id(&self) -> u32 {
+        self.seq_id
+    }
+
     #[allow(clippy::should_implement_trait)]
     /// Generate the next value and return it.
     ///

--- a/tests/run_tests.lua
+++ b/tests/run_tests.lua
@@ -33,6 +33,7 @@ box.once('bootstrap_tests', function()
     box.schema.user.grant('test_user', 'read,write,execute,create,drop', 'universe')
 
     box.schema.sequence.create('test_seq')
+    box.schema.sequence.create('test_drop_seq')
 
     box.schema.func.create('test_stored_proc')
     box.schema.func.create('test_schema_update')

--- a/tests/src/box.rs
+++ b/tests/src/box.rs
@@ -754,6 +754,14 @@ pub fn sequence_set() {
     assert_eq!(seq.next().unwrap(), 100);
 }
 
+pub fn sequence_drop() {
+    let mut seq = Sequence::find("test_drop_seq").unwrap().unwrap();
+    assert_eq!(seq.next().unwrap(), 1);
+
+    tarantool::schema::sequence::drop_sequence(seq.id()).unwrap();
+    assert!(Sequence::find("test_drop_seq").unwrap().is_none())
+}
+
 pub fn space_create_opt_default() {
     let opts = SpaceCreateOptions::default();
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -429,6 +429,7 @@ fn run_tests(cfg: TestConfig) -> Result<bool, io::Error> {
                 r#box::sequence_get_by_name,
                 r#box::sequence_iterate,
                 r#box::sequence_set,
+                r#box::sequence_drop,
                 r#box::space_create_opt_default,
                 r#box::space_create_opt_if_not_exists,
                 r#box::space_create_id_increment,


### PR DESCRIPTION
```(SQL)
CREATE SEQUENCE serial_01 CYCLE;
SELECT nextval('serial_01');
DROP SEQUENCE serial_01;
```

```
Tarantool error: DropSequence: Can't drop sequence 'serial_01': the sequence has data
```