### PR TITLE
fix: support 'np' and 'pp' iterator types

### DIFF
--- a/tarantool/src/index.rs
+++ b/tarantool/src/index.rs
@@ -88,8 +88,14 @@ pub enum IteratorType {
     /// key overlaps x
     Overlaps = 10,
 
-    /// tuples in distance ascending order from specified point
+    /// tuples as they move away from x point
     Neighbor = 11,
+
+    /// next prefix, ASC order
+    NP = 12,
+
+    /// previous prefix, DESC order
+    PP = 13,
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This parch adds `NP` (next prefix) and `PP` (previous prefix) variants to `IteratorType` enum, matching the new Tarantool iterators for memtx tree indexes. These iterators perform prefix-based string comparison on the last key part and fall back to `gt`/`lt` if it is not a string.

See https://github.com/tarantool/tarantool/pull/10028